### PR TITLE
Add 'pak' install script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,8 @@ RUN quarto install tinytex
 # Install R packages with 'pak'
 RUN install2.r pak
 COPY pkg.lock .
-RUN R -e 'pak::lockfile_install(update = FALSE)'
+COPY snippets/r-rocker-build.R .
+RUN Rscript r-rocker-build.R
 
 # Install Python packages with 'uv'
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/

--- a/snippets/r-rocker-build.R
+++ b/snippets/r-rocker-build.R
@@ -1,0 +1,11 @@
+#!/usr/bin/env Rscript
+
+# Install packages from lockfile; always exits cleanly on failure
+tryCatch(
+  pak::lockfile_install(update = FALSE),
+  error = function(cond) {
+    message("Lockfile install failed:")
+    message(conditionMessage(cond))
+    NA
+  }
+)


### PR DESCRIPTION
Extract `pak::lockfile_install()` into a standalone R script to improve error handling in Docker builds.

- replace inline `R -e` command with R script usage
- catch R errors so the Docker build does not fail
